### PR TITLE
Lane name empty exception is not documented at `audio.js` (#195)

### DIFF
--- a/src/static/packet_conv/audio.js
+++ b/src/static/packet_conv/audio.js
@@ -36,6 +36,7 @@ export const SILENT_AUDIO_PACKET_TYPE_ID = 0x11;
  * @throws {TypeError} If `audio_pcm` is not `Float32Array`
  * @throws {TypeError} If `lane_name` is not `string`
  * @throws {TypeError} If `ext_bytes` is not `Uint8Array`
+ * @throws {RangeError} If `lane_name` is empty `string`
  * @throws {RangeError} If ``lane_name`` has non ascii or control ascii characters
  * @throws {RangeError} If ``lane_name`` has over 3 characters
  * @throws {RangeError} If ``ext_bytes`` has over 255 bytes

--- a/src/static/packet_conv/audio.js
+++ b/src/static/packet_conv/audio.js
@@ -37,9 +37,9 @@ export const SILENT_AUDIO_PACKET_TYPE_ID = 0x11;
  * @throws {TypeError} If `lane_name` is not `string`
  * @throws {TypeError} If `ext_bytes` is not `Uint8Array`
  * @throws {RangeError} If `lane_name` is empty `string`
- * @throws {RangeError} If ``lane_name`` has non ascii or control ascii characters
- * @throws {RangeError} If ``lane_name`` has over 3 characters
- * @throws {RangeError} If ``ext_bytes`` has over 255 bytes
+ * @throws {RangeError} If `lane_name` has non ascii or control ascii characters
+ * @throws {RangeError} If `lane_name` has over 3 characters
+ * @throws {RangeError} If `ext_bytes` has over 255 bytes
  */
 export function packet_audio_encode(audio_pcm, lane_name, ext_bytes = new Uint8Array(0), silent_threshold_dbfs = -20.0) {
   // Arguments type checking


### PR DESCRIPTION
## Description

Close #195

## Checks

- [x] Lint or build passed
