### PR TITLE
No JSDoc class and typo in `RawAudioStreamPlay` (#209)

### DIFF
--- a/src/static/audio_connect/RawAudioStreamPlay.js
+++ b/src/static/audio_connect/RawAudioStreamPlay.js
@@ -1,5 +1,5 @@
 /**
- * @file Play audion from raw float array stream
+ * @file Play audio from raw float array stream
  *
  * @author aKuad
  */

--- a/src/static/audio_connect/RawAudioStreamPlay.js
+++ b/src/static/audio_connect/RawAudioStreamPlay.js
@@ -4,6 +4,9 @@
  * @author aKuad
  */
 
+/**
+ * Play audion from raw float array stream
+ */
 export class RawAudioStreamPlay {
   /**
    * Audio context instance (Web Audio API) for audio controlling


### PR DESCRIPTION
## Description

Close #209

## Checks

- [x] Lint or build passed
