### PR TITLE
No argument check for `silent_threshold_dbfs` in `packet_audio_encode` (#213)

### DIFF
--- a/src/static/packet_conv/audio.js
+++ b/src/static/packet_conv/audio.js
@@ -32,15 +32,18 @@ export const SILENT_AUDIO_PACKET_TYPE_ID = 0x11;
  * @param {Float32Array} audio_pcm Audio PCM
  * @param {string} lane_name Lane name of view in mixer-client
  * @param {Uint8Array} ext_bytes User's custom external data
+ * @param {number} silent_threshold_dbfs Under this dBFS input will be ignored
  * @returns {Uint8Array} Encoded packet
  *
  * @throws {TypeError} If `audio_pcm` is not `Float32Array`
  * @throws {TypeError} If `lane_name` is not `string`
  * @throws {TypeError} If `ext_bytes` is not `Uint8Array`
+ * @throws {TypeError} If `silent_threshold_dbfs` is not `number`
  * @throws {RangeError} If `lane_name` is empty `string`
  * @throws {RangeError} If `lane_name` has non ascii or control ascii characters
  * @throws {RangeError} If `lane_name` has over 3 characters
  * @throws {RangeError} If `ext_bytes` has over 255 bytes
+ * @throws {RangeError} If `silent_threshold_dbfs` is positive value
  */
 export function packet_audio_encode(audio_pcm, lane_name, ext_bytes = new Uint8Array(0), silent_threshold_dbfs = -20.0) {
   // Arguments type checking
@@ -52,6 +55,9 @@ export function packet_audio_encode(audio_pcm, lane_name, ext_bytes = new Uint8A
   }
   if(!(ext_bytes instanceof Uint8Array)) {
     throw new TypeError(`ext_bytes must be Uint8Array, but got ${typeof_detail(ext_bytes)}`);
+  }
+  if(typeof silent_threshold_dbfs !== "number") {
+    throw new TypeError(`silent_threshold_dbfs must be number, but got ${typeof_detail(silent_threshold_dbfs)}`);
   }
 
   // Arguments range checking
@@ -66,6 +72,9 @@ export function packet_audio_encode(audio_pcm, lane_name, ext_bytes = new Uint8A
   }
   if(ext_bytes.length > 255) {
     throw new RangeError(`For ext_bytes, over 255 bytes data is not allowed, but got ${ext_bytes.length} bytes`);
+  }
+  if(silent_threshold_dbfs > 0) {
+    throw new RangeError(`silent_threshold_dbfs must be 0 or negative value, but got ${silent_threshold_dbfs}`);
   }
 
   const audio_data_int16t = Int16Array.from(audio_pcm, e => e*32767); // *32767: float32(-1, 1) to int16(-32768, 32767)

--- a/src/tests/js_denotest/packet_conv/Test_audio.js
+++ b/src/tests/js_denotest/packet_conv/Test_audio.js
@@ -150,12 +150,13 @@ Deno.test(async function err_cases(t) {
     const lane_name = "ABC";
     const ext_bytes = new Uint8Array([1,2,3,4]);
 
-    assertThrows(() => packet_audio_encode("", lane_name, ext_bytes), TypeError, "audio_pcm must be Float32Array, but got string");
+    assertThrows(() => packet_audio_encode("", lane_name, ext_bytes           ), TypeError, "audio_pcm must be Float32Array, but got string");
     //                                     ~~ as non Float32Array
-    assertThrows(() => packet_audio_encode(audio_pcm,  1, ext_bytes), TypeError, "lane_name must be string, but got number");
+    assertThrows(() => packet_audio_encode(audio_pcm,  1, ext_bytes           ), TypeError, "lane_name must be string, but got number");
     //                                                 ~ as non string
-    assertThrows(() => packet_audio_encode(audio_pcm, lane_name, ""), TypeError, "ext_bytes must be Uint8Array, but got string");
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name, ""           ), TypeError, "ext_bytes must be Uint8Array, but got string");
     //                                                           ~~ as non Uint8Array
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name, ext_bytes, ""), TypeError, "silent_threshold_dbfs must be number, but got string");
   });
 
 
@@ -176,11 +177,12 @@ Deno.test(async function err_cases(t) {
     const lane_name_over_len      = "ABCD";
     const ext_bytes_over_len      = new Uint8Array(256);
 
-    assertThrows(() => packet_audio_encode(audio_pcm, ""                     , ext_bytes), RangeError, "lane_name can't be empty string");
-    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_non_ascii    , ext_bytes), RangeError, "For lane_name, non ascii or control ascii characters are not allowed");
-    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_control_ascii, ext_bytes), RangeError, "For lane_name, non ascii or control ascii characters are not allowed");
-    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_over_len     , ext_bytes), RangeError, `For lane_name, over 3 characters string is not allowed, but got ${lane_name_over_len.length} characters`);
-    assertThrows(() => packet_audio_encode(audio_pcm, lane_name, ext_bytes_over_len     ), RangeError, `For ext_bytes, over 255 bytes data is not allowed, but got ${ext_bytes_over_len.length} bytes`);
+    assertThrows(() => packet_audio_encode(audio_pcm, ""                     , ext_bytes   ), RangeError, "lane_name can't be empty string");
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_non_ascii    , ext_bytes   ), RangeError, "For lane_name, non ascii or control ascii characters are not allowed");
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_control_ascii, ext_bytes   ), RangeError, "For lane_name, non ascii or control ascii characters are not allowed");
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name_over_len     , ext_bytes   ), RangeError, `For lane_name, over 3 characters string is not allowed, but got ${lane_name_over_len.length} characters`);
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name, ext_bytes_over_len        ), RangeError, `For ext_bytes, over 255 bytes data is not allowed, but got ${ext_bytes_over_len.length} bytes`);
+    assertThrows(() => packet_audio_encode(audio_pcm, lane_name              , ext_bytes, 1), RangeError, "silent_threshold_dbfs must be 0 or negative value, but got 1");
   });
 
 


### PR DESCRIPTION
## Description

Fix #213

## Checks

- [ ] Created or fixed test code
- [ ] Tests can cover all features
- ~~if can't: test support utilities added~~
- [ ] All tests passed
