### PR TITLE
No longer need `.gitignore` for python (#251)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Python environment files
-__pycache__
-.venv*
-
 # Deno environment files
 *coverage
 


### PR DESCRIPTION
## Description

Resolve #251
